### PR TITLE
Added Email subject parsing and configurable preview lines size

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,6 +12,7 @@
 		"MailTemplate":  ":incoming_envelope: _From: **%v**_\n>_%v_\n\n%v",
         "StartTLS":      false,
 		"Disabled":      false,
-		"Debug":         true
+		"Debug":         true,
+		"LinesToPreview":10
 	}
 ]

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ type config struct {
 	MailTemplate   string
 	Debug          bool
 	Disabled       bool
+        LinesToPreview int
 }
 
 var Version = "3.0-dev"


### PR DESCRIPTION
I extracted out the preview lines variable into the config.json.
I added some logic to parse out the channel from the email subject. Feel free to change the code as you see fit. This is my first go at go.