### PR TITLE
Added Self Signed Certs to TLS

### DIFF
--- a/mmail/config.go
+++ b/mmail/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	MattermostPass    string
 	ImapServer        string
 	StartTLS          bool
+	TLSAcceptAllCerts bool
 	Email             string
 	EmailPass         string
 	MailTemplate      string

--- a/mmail/mattermail.go
+++ b/mmail/mattermail.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"crypto/tls"
 
 	"github.com/jhillyerd/go.enmime"
 	"github.com/mattermost/platform/model"
@@ -71,7 +72,11 @@ func (m *MatterMail) CheckImapConnection() error {
 
 	if m.cfg.StartTLS && m.imapClient.Caps["STARTTLS"] {
 		m.debg.Println("CheckImapConnection:StartTLS")
-		_, err = m.imapClient.StartTLS(nil)
+		var tconfig tls.Config
+		if m.cfg.TLSAcceptAllCerts {
+			tconfig.InsecureSkipVerify = true
+		}
+		_, err = m.imapClient.StartTLS(&tconfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This adds a new config option to accept self signed certs (TLSAcceptAllCerts) when using a TLS connection.  This relates to issue #19.  Please check the code, I've never used Go before.