### PR TITLE
Improve subject regex

### DIFF
--- a/mmail/mattermail.go
+++ b/mmail/mattermail.go
@@ -431,7 +431,7 @@ func (m *MatterMail) getDirectChannelIDByName(client *model.Client, channelList 
 	return directChannel.Id
 }
 
-var channelRegex = regexp.MustCompile(`^\s*?\[\s*?([#@][A-Za-z0-9\-_]*)\s*?\]`)
+var channelRegex = regexp.MustCompile(`^\s*?[A-Za-z0-9\-_:]*?\s*?\[\s*?([#@][A-Za-z0-9\-_]*)\s*?\]`)
 
 // getChannelFromSubject extract channel from subject ex:
 // getChannelFromSubject([#mychannel] blablanla) => #mychannel

--- a/mmail/mattermail.go
+++ b/mmail/mattermail.go
@@ -436,7 +436,7 @@ func (m *MatterMail) getDirectChannelIDByName(client *model.Client, channelList 
 	return directChannel.Id
 }
 
-var channelRegex = regexp.MustCompile(`^\s*?[A-Za-z0-9\-_:]*?\s*?\[\s*?([#@][A-Za-z0-9\-_]*)\s*?\]`)
+var channelRegex = regexp.MustCompile(`\s*?[A-Za-z0-9\-_:]*?\s*?\[*?\s*?[A-Za-z0-9\-_]*\s*?\]*?\s*?[A-Za-z0-9\-_:]*?\s*?\[\s*?([#@][A-Za-z0-9\-_]*)\s*?\]`)
 
 // getChannelFromSubject extract channel from subject ex:
 // getChannelFromSubject([#mychannel] blablanla) => #mychannel


### PR DESCRIPTION
#Motivation
* Up to now getting the channel or group id from a subject fails if the [#...] part is not at the beginning of the subject
* Thus, emails which are replied to are delivered to the default group instead of delivering it to the specified group
* E.g. Re: [#...] is problematic

# Solution
* Allow arbitrary letters and signs and colons in front of the channel or group definition in the subject line.